### PR TITLE
Remove old event entry from news.json

### DIFF
--- a/src/_data/news.json
+++ b/src/_data/news.json
@@ -1,14 +1,5 @@
 [
   {
-    "id": "event-20260401",
-    "type": "event",
-    "title": "FAIR Data Symposium 2026",
-    "date": "2026-04-01",
-    "summary": "CDIF Website edit session.",
-    "link": "https://fair-symposium.org",
-    "tags": ["CODATA", "CDIF"]
-  },
-  {
     "id": "event-2",
     "type": "event",
     "title": "FAIR Data Symposium 2026",


### PR DESCRIPTION
Removed outdated event entry for FAIR Data Symposium 2026.