### PR TITLE
Fix Tailwind CSS race condition in local dev builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
   "version": "1.0.0",
   "description": "CODATA Cross-Domain Information Framework Website",
   "scripts": {
-    "prestart": "mkdir -p _site/assets/css",
+    "prestart": "node -e \"require('fs').mkdirSync('_site/assets/css', { recursive: true })\"",
     "start": "npm-run-all -p dev:*",
     "dev:11ty": "eleventy --serve --watch",
     "dev:tailwind": "tailwindcss -i ./src/styles/tailwind.css -o ./_site/assets/css/style.css --watch",
-    "prebuild": "mkdir -p _site/assets/css",
+    "prebuild": "node -e \"require('fs').mkdirSync('_site/assets/css', { recursive: true })\"",
     "build": "npm-run-all -s build:*",
     "build:eleventy": "eleventy",
     "build:tailwind": "tailwindcss -i ./src/styles/tailwind.css -o ./_site/assets/css/style.css --minify",

--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
   "version": "1.0.0",
   "description": "CODATA Cross-Domain Information Framework Website",
   "scripts": {
+    "prestart": "mkdir -p _site/assets/css",
     "start": "npm-run-all -p dev:*",
     "dev:11ty": "eleventy --serve --watch",
     "dev:tailwind": "tailwindcss -i ./src/styles/tailwind.css -o ./_site/assets/css/style.css --watch",
+    "prebuild": "mkdir -p _site/assets/css",
     "build": "npm-run-all -s build:*",
     "build:eleventy": "eleventy",
     "build:tailwind": "tailwindcss -i ./src/styles/tailwind.css -o ./_site/assets/css/style.css --minify",


### PR DESCRIPTION
## Summary
- Add `prestart` and `prebuild` npm hooks to create `_site/assets/css/` directory before parallel tasks run
- Fixes silent Tailwind CSS build failure when the output directory doesn't exist yet, which caused missing styles in local dev

## Test plan
- [ ] Run `npm start` from a clean checkout (no `_site/` directory) and verify styles load at `http://localhost:8080/cdif-www-mock/`
- [ ] Run `npm run build` and verify `_site/assets/css/style.css` is generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)